### PR TITLE
Replaces paymentConfirmationError w/ generalError

### DIFF
--- a/cartridges/int_shoppay_sfra/cartridge/client/default/js/helpers/shoppayHelper.js
+++ b/cartridges/int_shoppay_sfra/cartridge/client/default/js/helpers/shoppayHelper.js
@@ -352,7 +352,7 @@ function setSessionListeners(session) {
             session.completePaymentConfirmationRequest({
                 errors: [
                     {
-                        type: "paymentConfirmationError",
+                        type: "generalError",
                         message: technicalErrorMsg
                     }
                 ]
@@ -370,7 +370,7 @@ function setSessionListeners(session) {
             session.completePaymentConfirmationRequest({
                 errors: [
                     {
-                        type: "paymentConfirmationError",
+                        type: "generalError",
                         message: errorMsg
                     }
                 ]


### PR DESCRIPTION
Closes #6 

`paymentConfirmationError` doesn't exist.